### PR TITLE
feat: Implement FII use cases and Hilt module

### DIFF
--- a/app/src/main/java/com/felipepalma14/cotajusta/di/UseCaseModule.kt
+++ b/app/src/main/java/com/felipepalma14/cotajusta/di/UseCaseModule.kt
@@ -1,0 +1,48 @@
+package com.felipepalma14.cotajusta.di
+
+import com.felipepalma14.cotajusta.domain.repository.FiiRepository
+import com.felipepalma14.cotajusta.domain.usecase.GetFavoriteFiisUseCase
+import com.felipepalma14.cotajusta.domain.usecase.GetFiisUseCase
+import com.felipepalma14.cotajusta.domain.usecase.GetLocalFiisUseCase
+import com.felipepalma14.cotajusta.domain.usecase.SaveFiisUseCase
+import com.felipepalma14.cotajusta.domain.usecase.ToggleFavoriteFiiUseCase
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object UseCaseModule {
+
+    @Provides
+    @Singleton
+    fun provideGetFiisUseCase(repository: FiiRepository): GetFiisUseCase {
+        return GetFiisUseCase(repository)
+    }
+
+    @Provides
+    @Singleton
+    fun provideGetLocalFiisUseCase(repository: FiiRepository): GetLocalFiisUseCase {
+        return GetLocalFiisUseCase(repository)
+    }
+
+    @Provides
+    @Singleton
+    fun provideSaveFiisUseCase(repository: FiiRepository): SaveFiisUseCase {
+        return SaveFiisUseCase(repository)
+    }
+
+    @Provides
+    @Singleton
+    fun provideToggleFavoriteFiiUseCase(repository: FiiRepository): ToggleFavoriteFiiUseCase {
+        return ToggleFavoriteFiiUseCase(repository)
+    }
+
+    @Provides
+    @Singleton
+    fun provideGetFavoriteFiisUseCase(repository: FiiRepository): GetFavoriteFiisUseCase {
+        return GetFavoriteFiisUseCase(repository)
+    }
+}

--- a/app/src/main/java/com/felipepalma14/cotajusta/domain/usecase/GetFavoriteFiisUseCase.kt
+++ b/app/src/main/java/com/felipepalma14/cotajusta/domain/usecase/GetFavoriteFiisUseCase.kt
@@ -1,0 +1,12 @@
+package com.felipepalma14.cotajusta.domain.usecase
+
+import com.felipepalma14.cotajusta.data.local.entity.FiiEntity
+import com.felipepalma14.cotajusta.domain.repository.FiiRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetFavoriteFiisUseCase @Inject constructor(
+    private val repository: FiiRepository
+) {
+    suspend operator fun invoke(): Flow<List<FiiEntity>> = repository.getFavoriteFiis()
+}

--- a/app/src/main/java/com/felipepalma14/cotajusta/domain/usecase/GetFiisUseCase.kt
+++ b/app/src/main/java/com/felipepalma14/cotajusta/domain/usecase/GetFiisUseCase.kt
@@ -1,0 +1,12 @@
+package com.felipepalma14.cotajusta.domain.usecase
+
+import com.felipepalma14.cotajusta.data.model.FiiResponse
+import com.felipepalma14.cotajusta.domain.repository.FiiRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetFiisUseCase @Inject constructor(
+    private val repository: FiiRepository
+) {
+    suspend operator fun invoke(): Flow<Result<FiiResponse>> = repository.getFiis()
+}

--- a/app/src/main/java/com/felipepalma14/cotajusta/domain/usecase/GetLocalFiisUseCase.kt
+++ b/app/src/main/java/com/felipepalma14/cotajusta/domain/usecase/GetLocalFiisUseCase.kt
@@ -1,0 +1,12 @@
+package com.felipepalma14.cotajusta.domain.usecase
+
+import com.felipepalma14.cotajusta.data.local.entity.FiiEntity
+import com.felipepalma14.cotajusta.domain.repository.FiiRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetLocalFiisUseCase @Inject constructor(
+    private val repository: FiiRepository
+) {
+    suspend operator fun invoke(): Flow<List<FiiEntity>> = repository.getLocalFiis()
+}

--- a/app/src/main/java/com/felipepalma14/cotajusta/domain/usecase/SaveFiisUseCase.kt
+++ b/app/src/main/java/com/felipepalma14/cotajusta/domain/usecase/SaveFiisUseCase.kt
@@ -1,0 +1,11 @@
+package com.felipepalma14.cotajusta.domain.usecase
+
+import com.felipepalma14.cotajusta.data.local.entity.FiiEntity
+import com.felipepalma14.cotajusta.domain.repository.FiiRepository
+import javax.inject.Inject
+
+class SaveFiisUseCase @Inject constructor(
+    private val repository: FiiRepository
+) {
+    suspend operator fun invoke(fiis: List<FiiEntity>) = repository.insertFiis(fiis)
+}

--- a/app/src/main/java/com/felipepalma14/cotajusta/domain/usecase/ToggleFavoriteFiiUseCase.kt
+++ b/app/src/main/java/com/felipepalma14/cotajusta/domain/usecase/ToggleFavoriteFiiUseCase.kt
@@ -1,0 +1,10 @@
+package com.felipepalma14.cotajusta.domain.usecase
+
+import com.felipepalma14.cotajusta.domain.repository.FiiRepository
+import javax.inject.Inject
+
+class ToggleFavoriteFiiUseCase @Inject constructor(
+    private val repository: FiiRepository
+) {
+    suspend operator fun invoke(code: String, isFavorite: Boolean) = repository.setFavorite(code, isFavorite)
+}

--- a/app/src/test/java/com/felipepalma14/cotajusta/domain/usecase/GetFavoriteFiisUseCaseTest.kt
+++ b/app/src/test/java/com/felipepalma14/cotajusta/domain/usecase/GetFavoriteFiisUseCaseTest.kt
@@ -1,0 +1,61 @@
+package com.felipepalma14.cotajusta.domain.usecase
+
+import com.felipepalma14.cotajusta.data.local.entity.FiiEntity
+import com.felipepalma14.cotajusta.domain.repository.FiiRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GetFavoriteFiisUseCaseTest {
+    private lateinit var repository: FiiRepository
+    private lateinit var useCase: GetFavoriteFiisUseCase
+
+    @Before
+    fun setUp() {
+        repository = mockk()
+        useCase = GetFavoriteFiisUseCase(repository)
+    }
+
+    @Test
+    fun `given favorite fiis when invoke is called then returns favorite fiis from repository`() = runTest {
+        // Given
+        val favoriteFii = createTestFiiEntity(isFavorite = true)
+        val expectedFiis = listOf(favoriteFii)
+        coEvery { repository.getFavoriteFiis() } returns flowOf(expectedFiis)
+
+        // When
+        val result = useCase()
+        val emitted = mutableListOf<List<FiiEntity>>()
+        result.collect { emitted.add(it) }
+
+        // Then
+        assertEquals(expectedFiis, emitted.first())
+    }
+
+    private fun createTestFiiEntity(isFavorite: Boolean = true) = FiiEntity(
+        code = "TSTF11",
+        name = "Test FII",
+        change = 1.0,
+        closingPrice = 100.0,
+        dividendYield = 0.05,
+        high = 105.0,
+        lastPrice = 102.0,
+        lastYearHigh = 110.0,
+        lastYearLow = 90.0,
+        low = 99.0,
+        priceOpen = 100.0,
+        segment = "Segment",
+        shares = 1000,
+        targetAudience = "General",
+        typeOfManagement = "Active",
+        volume = 10000.0,
+        volumeAvg = 9500.0,
+        isFavorite = isFavorite
+    )
+}

--- a/app/src/test/java/com/felipepalma14/cotajusta/domain/usecase/GetFiisUseCaseTest.kt
+++ b/app/src/test/java/com/felipepalma14/cotajusta/domain/usecase/GetFiisUseCaseTest.kt
@@ -1,0 +1,76 @@
+package com.felipepalma14.cotajusta.domain.usecase
+
+import com.felipepalma14.cotajusta.data.model.Fii
+import com.felipepalma14.cotajusta.data.model.FiiResponse
+import com.felipepalma14.cotajusta.domain.repository.FiiRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GetFiisUseCaseTest {
+    private lateinit var repository: FiiRepository
+    private lateinit var useCase: GetFiisUseCase
+
+    @Before
+    fun setUp() {
+        repository = mockk()
+        useCase = GetFiisUseCase(repository)
+    }
+
+    @Test
+    fun `given successful repository response when invoke is called then returns success with fiis`() = runTest {
+        // Given
+        val fii = Fii(
+            change = 1.0,
+            closingPrice = 100.0,
+            dividendYield = 0.05,
+            high = 105.0,
+            lastPrice = 102.0,
+            lastYearHigh = 110.0,
+            lastYearLow = 90.0,
+            low = 99.0,
+            name = "Test FII",
+            priceOpen = 100.0,
+            segment = "Segment",
+            shares = 1000,
+            symbol = "TSTF11",
+            targetAudience = "General",
+            typeOfManagement = "Active",
+            volume = 10000.0,
+            volumeAvg = 9500.0
+        )
+        val response = FiiResponse(listOf(fii))
+        coEvery { repository.getFiis() } returns flowOf(Result.success(response))
+
+        // When
+        val result = useCase()
+        val emitted = mutableListOf<Result<FiiResponse>>()
+        result.collect { emitted.add(it) }
+
+        // Then
+        assertTrue(emitted.first().isSuccess)
+        assertEquals(response, emitted.first().getOrNull())
+    }
+
+    @Test
+    fun `given repository error when invoke is called then returns failure`() = runTest {
+        // Given
+        val exception = RuntimeException("Error")
+        coEvery { repository.getFiis() } returns flowOf(Result.failure(exception))
+
+        // When
+        val result = useCase()
+        val emitted = mutableListOf<Result<FiiResponse>>()
+        result.collect { emitted.add(it) }
+
+        // Then
+        assertTrue(emitted.first().isFailure)
+    }
+}

--- a/app/src/test/java/com/felipepalma14/cotajusta/domain/usecase/GetLocalFiisUseCaseTest.kt
+++ b/app/src/test/java/com/felipepalma14/cotajusta/domain/usecase/GetLocalFiisUseCaseTest.kt
@@ -1,0 +1,61 @@
+package com.felipepalma14.cotajusta.domain.usecase
+
+import com.felipepalma14.cotajusta.data.local.entity.FiiEntity
+import com.felipepalma14.cotajusta.domain.repository.FiiRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GetLocalFiisUseCaseTest {
+    private lateinit var repository: FiiRepository
+    private lateinit var useCase: GetLocalFiisUseCase
+
+    @Before
+    fun setUp() {
+        repository = mockk()
+        useCase = GetLocalFiisUseCase(repository)
+    }
+
+    @Test
+    fun `given local fiis when invoke is called then returns fiis from repository`() = runTest {
+        // Given
+        val fiiEntity = createTestFiiEntity()
+        val expectedFiis = listOf(fiiEntity)
+        coEvery { repository.getLocalFiis() } returns flowOf(expectedFiis)
+
+        // When
+        val result = useCase()
+        val emitted = mutableListOf<List<FiiEntity>>()
+        result.collect { emitted.add(it) }
+
+        // Then
+        assertEquals(expectedFiis, emitted.first())
+    }
+
+    private fun createTestFiiEntity() = FiiEntity(
+        code = "TSTF11",
+        name = "Test FII",
+        change = 1.0,
+        closingPrice = 100.0,
+        dividendYield = 0.05,
+        high = 105.0,
+        lastPrice = 102.0,
+        lastYearHigh = 110.0,
+        lastYearLow = 90.0,
+        low = 99.0,
+        priceOpen = 100.0,
+        segment = "Segment",
+        shares = 1000,
+        targetAudience = "General",
+        typeOfManagement = "Active",
+        volume = 10000.0,
+        volumeAvg = 9500.0,
+        isFavorite = false
+    )
+}

--- a/app/src/test/java/com/felipepalma14/cotajusta/domain/usecase/SaveFiisUseCaseTest.kt
+++ b/app/src/test/java/com/felipepalma14/cotajusta/domain/usecase/SaveFiisUseCaseTest.kt
@@ -1,0 +1,58 @@
+package com.felipepalma14.cotajusta.domain.usecase
+
+import com.felipepalma14.cotajusta.data.local.entity.FiiEntity
+import com.felipepalma14.cotajusta.domain.repository.FiiRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SaveFiisUseCaseTest {
+    private lateinit var repository: FiiRepository
+    private lateinit var useCase: SaveFiisUseCase
+
+    @Before
+    fun setUp() {
+        repository = mockk()
+        useCase = SaveFiisUseCase(repository)
+    }
+
+    @Test
+    fun `given list of fiis when invoke is called then saves fiis in repository`() = runTest {
+        // Given
+        val fiiEntity = createTestFiiEntity()
+        val fiisToSave = listOf(fiiEntity)
+        coEvery { repository.insertFiis(fiisToSave) } returns Unit
+
+        // When
+        useCase(fiisToSave)
+
+        // Then
+        coVerify { repository.insertFiis(fiisToSave) }
+    }
+
+    private fun createTestFiiEntity() = FiiEntity(
+        code = "TSTF11",
+        name = "Test FII",
+        change = 1.0,
+        closingPrice = 100.0,
+        dividendYield = 0.05,
+        high = 105.0,
+        lastPrice = 102.0,
+        lastYearHigh = 110.0,
+        lastYearLow = 90.0,
+        low = 99.0,
+        priceOpen = 100.0,
+        segment = "Segment",
+        shares = 1000,
+        targetAudience = "General",
+        typeOfManagement = "Active",
+        volume = 10000.0,
+        volumeAvg = 9500.0,
+        isFavorite = false
+    )
+}

--- a/app/src/test/java/com/felipepalma14/cotajusta/domain/usecase/ToggleFavoriteFiiUseCaseTest.kt
+++ b/app/src/test/java/com/felipepalma14/cotajusta/domain/usecase/ToggleFavoriteFiiUseCaseTest.kt
@@ -1,0 +1,36 @@
+package com.felipepalma14.cotajusta.domain.usecase
+
+import com.felipepalma14.cotajusta.domain.repository.FiiRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ToggleFavoriteFiiUseCaseTest {
+    private lateinit var repository: FiiRepository
+    private lateinit var useCase: ToggleFavoriteFiiUseCase
+
+    @Before
+    fun setUp() {
+        repository = mockk()
+        useCase = ToggleFavoriteFiiUseCase(repository)
+    }
+
+    @Test
+    fun `given fii code when invoke is called then updates favorite status in repository`() = runTest {
+        // Given
+        val code = "TSTF11"
+        val isFavorite = true
+        coEvery { repository.setFavorite(code, isFavorite) } returns Unit
+
+        // When
+        useCase(code, isFavorite)
+
+        // Then
+        coVerify { repository.setFavorite(code, isFavorite) }
+    }
+}


### PR DESCRIPTION

This commit introduces several use cases for managing FII (Real Estate Investment Fund) data and a Hilt module to provide them.

New Use Cases:
- `GetFavoriteFiisUseCase`: Fetches a list of favorite FIIs from the repository.
- `GetFiisUseCase`: Fetches FII data from the repository (likely from a remote source).
- `GetLocalFiisUseCase`: Fetches FII data stored locally.
- `SaveFiisUseCase`: Saves a list of FIIs to the repository.
- `ToggleFavoriteFiiUseCase`: Toggles the favorite status of an FII.

Unit tests using MockK and Kotlin Coroutines Test have been added for each use case to ensure their correctness.

A new Hilt module, `UseCaseModule`, has been created to provide instances of these use cases for dependency injection.